### PR TITLE
Revision of interpreter output

### DIFF
--- a/_data/examples.json
+++ b/_data/examples.json
@@ -14,28 +14,36 @@
           "url": "Coloration.xml"
         },
         {
-          "label": "Coloration with dot",
+          "label": "Coloration with dot of augmentation",
           "url": "colorWDot.xml"
         },
         {
-          "label": "Dot of perfection",
-          "url": "perfDot.xml"
-        },
-        {
-          "label": "Simple Dot",
+          "label": "Simple dot of augmentation",
           "url": "simpleDot.xml"
         },
         {
-          "label": "All unalterable imperfect",
+          "label": "Unalterable imperfect",
           "url": "unalterableImperfect.xml"
         },
         {
-          "label": "Ante simile",
+          "label": "Imperfection 2: Dot of perfection",
+          "url": "perfDot.xml"
+        },
+        {
+          "label": "Imperfection 2: Ante simile",
           "url": "anteSim.xml"
+        },
+        {
+          "label": "Imperfection 3",
+          "url": "I3.xml"
         },
         {
           "label": "Alteration 1",
           "url": "Alt1.xml"
+        },
+        {
+          "label": "Alteration 2",
+          "url": "Alt2.xml"
         }
       ]
     }

--- a/examples/tests/Alt2.xml
+++ b/examples/tests/Alt2.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-Mensural.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-Mensural.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei meiversion="4.0.1" xmlns="http://www.music-encoding.org/ns/mei">
+    <meiHead meiversion="4.0.1">
+        <fileDesc>
+            <titleStmt>
+                <title>Test A.2 rule</title>
+                <editor>Anna Plaksin</editor>
+            </titleStmt>
+            <pubStmt>
+                <publisher>Early Music Theory</publisher>
+            </pubStmt>
+            <notesStmt>
+                <annot>An alterable note that is preceded by a dot of division followed by the equivalent of its own regular value and followed by a note or rest of the perfect unit next larger is altered.</annot>
+            </notesStmt>
+        </fileDesc>
+    </meiHead>
+    <music meiversion="4.0.1">
+        <body>
+            <mdiv>
+                <score>
+                    <scoreDef>
+                        <staffGrp>
+                            <staffDef n="1" label="voice" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" 
+                                tempus="3" prolatio="2" modusminor="2"/>
+                            <!--<staffDef n="2" label="reference" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" 
+                                tempus="3" prolatio="2" modusminor="2"/>-->
+                        </staffGrp>
+                    </scoreDef>
+                    <section>
+                        <staff n="1">
+                            <layer>
+                                <!--<note dur="brevis" pname="a" oct="4"/>-->
+                                <note dur="semibrevis" pname="a" oct="4"/>
+                                <dot form="div"/>
+                                <note dur="semibrevis" pname="a" oct="4"/>
+                                <note dur="semibrevis" pname="a" oct="4"/>
+                                <note dur="brevis" pname="a" oct="4"/>
+                                <dot form="aug" />
+                                <barLine form="dbl"/>
+                            </layer>
+                        </staff>
+                        <!--<staff n="2">
+                            <layer>
+                                <note dur="longa" pname="a" oct="4"/>
+                                <note dur="brevis" pname="a" oct="4"/>
+                                <barLine form="dbl"/>
+                            </layer>
+                        </staff>-->
+                    </section>
+                </score>
+            </mdiv>
+        </body>
+    </music>
+</mei>

--- a/examples/tests/I3.xml
+++ b/examples/tests/I3.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-Mensural.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-Mensural.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei meiversion="4.0.1" xmlns="http://www.music-encoding.org/ns/mei">
+    <meiHead meiversion="4.0.1">
+        <fileDesc>
+            <titleStmt>
+                <title>Test I.3 rule</title>
+                <editor>Anna Plaksin</editor>
+            </titleStmt>
+            <pubStmt>
+                <publisher>Early Music Theory</publisher>
+            </pubStmt>
+            <notesStmt>
+                <annot>
+                    A regularly perfect note that falls on the first subunit of its own unit and is 
+                    followed by any larger note or rest is ipso facto perfect.
+                </annot>
+            </notesStmt>
+        </fileDesc>
+    </meiHead>
+    <music meiversion="4.0.1">
+        <body>
+            <mdiv>
+                <score>
+                    <scoreDef>
+                        <staffGrp>
+                            <staffDef n="1" label="voice" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" 
+                                tempus="3" prolatio="2" modusminor="2" modusmaior="2"/>
+                            <!--<staffDef n="2" label="reference" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" 
+                                tempus="3" prolatio="2" modusminor="2" modusmaior="2"/>-->
+                        </staffGrp>
+                    </scoreDef>
+                    <section>
+                        <staff n="1">
+                            <layer>
+                                <note dur="brevis" pname="a" oct="4"/>
+                                <note dur="longa" pname="a" oct="4"/>
+                                <note dur="brevis" pname="a" oct="4"/>
+                                <barLine form="dbl"/>
+                            </layer>
+                        </staff>
+                        <!--<staff n="2">
+                            <layer>
+                                <note dur="longa" pname="a" oct="4"/>
+                                <note dur="longa" pname="a" oct="4"/>
+                                <barLine form="dbl"/>
+                            </layer>
+                        </staff>-->
+                    </section>
+                </score>
+            </mdiv>
+        </body>
+    </music>
+</mei>

--- a/js/MEIdoc.js
+++ b/js/MEIdoc.js
@@ -296,9 +296,9 @@ var MEIdoc = (() => {
 			annot.setAttribute("startid", "#" + eventID);
 			annot.setAttribute("type", "#mensural-interpreter");
 
-			let layer = this.doc.evaluate("./ancestor::mei:layer[1]", this.eventDict[eventID], nsResolver, 9).singleNodeValue;
+			let staff = this.doc.evaluate("./ancestor::mei:staff[1]", this.eventDict[eventID], nsResolver, 9).singleNodeValue;
 
-			layer.after(annot);
+			staff.appendChild(annot);
 
 			this.annots[eventID] = annot;
 			return annot;

--- a/js/MEIdoc.js
+++ b/js/MEIdoc.js
@@ -274,6 +274,12 @@ var MEIdoc = (() => {
 			}
 		}
 		
+		/**
+		 * Creates a new mei element with the given name and registers
+		 * it in the eventDict.
+		 * @param {string} elName 
+		 * @returns {DOMElement} created element
+		 */
 		addMeiElement(elName) {
 			let el = this.doc.createElementNS(nsResolver("mei"), elName);
 			let id = "ID" + uuidv4();
@@ -288,6 +294,11 @@ var MEIdoc = (() => {
 			return this.annots;
 		}
 
+		/**
+		 * Retrieves the annotation control event for the event with the given id.
+		 * @param {string} eventID xml:id of MEI event
+		 * @returns {DOMElement} <annot>
+		 */
 		getAnnotation (eventID) {
 			return this.annotations[eventID];
 		}
@@ -372,6 +383,14 @@ var MEIdoc = (() => {
 
 		}
 
+		/**
+		 * A convenient way to pipe XPath queries to the meiDoc.
+		 * Uses the internal ns-resolver.
+		 * @param {string} expression XPath expression
+		 * @param {DOMElement|Document} context context element or document
+		 * @param {integer} resultType https://developer.mozilla.org/en-US/docs/Web/API/Document/evaluate#result_types
+		 * @returns {XPathResult} result
+		 */
 		doXPathOnDoc(expression, context, resultType)
 		{
 			return this.doc.evaluate(expression, context, nsResolver, resultType);

--- a/js/MEIdoc.js
+++ b/js/MEIdoc.js
@@ -167,6 +167,7 @@ var MEIdoc = (() => {
 			this.idDict = {};
 			this.eventIdDict = {};
             this.sectionBlocks;
+			this.annots = {};
 			if(this.doc) this.initEventDict();
 			this.meiBlob = this.meiDoc ? new Blob([this.text], {type: 'text/xml'}) : null;
 			if(this.doc) this.getBlocksFromSections();
@@ -272,6 +273,38 @@ var MEIdoc = (() => {
 				this.eventIdDict[id] = element;
 			}
 		}
+		
+		addMeiElement(elName) {
+			let el = this.doc.createElementNS(nsResolver("mei"), elName);
+			let id = "ID" + uuidv4();
+			el.setAttribute("xml:id", id);
+			this.eventIdDict[id] = el;
+
+			return el;
+		}
+
+		/** @property {Object.<string,Object>} annotations event id to annotations */
+		get annotations () {
+			return this.annots;
+		}
+
+		getAnnotation (eventID) {
+			return this.annotations[eventID];
+		}
+		addAnnotation (eventID) {
+			let annot = this.addMeiElement("annot");
+			annot.setAttribute("startid", "#" + eventID);
+			annot.setAttribute("type", "#mensural-interpreter");
+
+			let layer = this.doc.evaluate("./ancestor::mei:layer[1]", this.eventDict[eventID], nsResolver, 9).singleNodeValue;
+
+			layer.after(annot);
+
+			this.annots[eventID] = annot;
+			return annot;
+		}
+
+		/** non-property related methods */
         
 		/**
 		 * Build mensurally coherent blocks from current document
@@ -337,6 +370,11 @@ var MEIdoc = (() => {
 				mergeAdjacentMensProp(staff);
 			}
 
+		}
+
+		doXPathOnDoc(expression, context, resultType)
+		{
+			return this.doc.evaluate(expression, context, nsResolver, resultType);
 		}
         
     }  

--- a/js/interpreter/alteration.js
+++ b/js/interpreter/alteration.js
@@ -11,6 +11,25 @@
 var alterate = (function() {
 
     /**
+     * Backward window support – find the previous note that's at least as
+     * long, or find a dot of division
+     * @param {Integer} level Level of the note
+     * @param {Integer} index Index of the current event (end point for the search)
+     * @param {Array} seq Array of events
+     * @return {Integer} Position if found (false if not)
+     */
+    function indexOfPrevLongerOrDot(level, index, seq){
+        for(var i=index-1; i>=0; i--)
+        {
+            if(rm.divisionDot(seq[i]) || rm.noteInt(seq[i])>level)
+            {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    /**
      * Check an event for evidence of alteration. Alters event if it falls
      * after a longer note followed by its own duration. Where there is
      * uncertainty about the intervening duration, rule out alteration if

--- a/js/interpreter/beatIndependentDurations.js
+++ b/js/interpreter/beatIndependentDurations.js
@@ -99,14 +99,14 @@ var basic = (function() {
 		// Anything imperfect and with an imperfect next longer note is trivial
 		for(var b=0; b<sectionBlocks.length; b++){
 			var mens = sectionBlocks[b].mens;
-			var menssum = rm.mensurSummary(mens);
+			//var menssum = rm.mensurSummary(mens);
 			//var alterableLevels = [2, 2, 2].concat(menssum).concat([2]);
-			var firstPerf = rm.firstPerfectLevel(mens);
+			//var firstPerf = rm.firstPerfectLevel(mens);
 			for(var e=0; e<sectionBlocks[b].events.length; e++){
 				var event = sectionBlocks[b].events[e];
 				if(rm.isNote(event) && !durIO.readDur(event)){
-					var level = rm.noteInt(event);
-					if(level < firstPerf && !rm.isAlterable(event, mens))
+					//var level = rm.noteInt(event);
+					if(!rm.notePerfectAsWhole(event, mens) && !rm.isAlterable(event, mens))
 					{
 						// Assume that actOnDots has already been run on all dotted notes
 						durIO.writeDurWithRule(event, mens, 'unalterableImperfect');

--- a/js/interpreter/beatIndependentDurations.js
+++ b/js/interpreter/beatIndependentDurations.js
@@ -243,7 +243,7 @@ var basic = (function() {
 			anteSim(sectionBlocks);
 
 			// write dur.ges => dur.intermediate * propMultiplier
-			durIO.setDurGesPerBlock(sectionBlocks);
+			//durIO.setDurGesPerBlock(sectionBlocks);
 		}
 	}
 

--- a/js/interpreter/beatIndependentDurations.js
+++ b/js/interpreter/beatIndependentDurations.js
@@ -76,7 +76,7 @@ var basic = (function() {
 				var event = sectionBlocks[b].events[e];
 				if(rm.augDot(event) && e){
 					var prev = sectionBlocks[b].events[e-1];
-					if(e && !prev.getAttributeNS(null, 'dur.intermediate'))
+					if(e && !durIO.readDur(prev))
 						if(rm.notePerfectAsWhole(prev, mens)){
 							durIO.writePerfection(prev, mens,'I.2.a.PerfDot');
 						} else {

--- a/js/interpreter/complexBeatAnalysis.js
+++ b/js/interpreter/complexBeatAnalysis.js
@@ -259,7 +259,7 @@ var complexBeats = (function() {
                 nextRemaining = afterTheEasyBits(sectionBlocks);
             }
 
-            durIO.setDurGesPerBlock(sectionBlocks);
+            //durIO.setDurGesPerBlock(sectionBlocks);
 
             updateBlocks(sectionBlocks);
 

--- a/js/interpreter/utils/durationUtils.js
+++ b/js/interpreter/utils/durationUtils.js
@@ -53,6 +53,49 @@ var durIO = (function() {
         return minims/MiB;
     }
 
+    /** instead of attributes, annotations could be used for custom MEI export */
+
+    function getAnnot(eventID, attrName) {
+        var attrEl = null;
+        
+        // pulling the gobal document like a bunny out of the hat is bad, 
+        // but just live with it in this one case...
+        if(meiFile.annotations[eventID])
+        {
+            let annot = meiFile.annotations[eventID];
+            attrEl = meiFile.doXPathOnDoc("./annot[@type='" + attrName + "']", annot, 9).singleNodeValue;
+        }
+        
+        return attrEl;
+    }
+
+    function setAnnot(eventID, dictObj) {
+        var annot;
+
+        // pulling the gobal document like a bunny out of the hat is bad, 
+        // but just live with it in this one case...
+        if(meiFile.annotations[eventID])
+        {
+            annot = meiFile.annotations[eventID];
+        }
+        else 
+        {
+            annot = meiFile.addAnnotation(eventID);
+        }
+
+        for (let attr in dictObj)
+        {
+            let attrAnnot = getAnnot(eventID, attr);
+            if(attrAnnot===null)
+            {
+                attrAnnot = meiFile.addMeiElement("annot");
+                attrAnnot.setAttribute("type", attr);
+            }
+            attrAnnot.innerHTML = dictObj[attr];
+            annot.appendChild(attrAnnot);
+        }
+    }
+
     function writeAttr(eventEl, dictObj) {
         for(let attr in dictObj)
         {
@@ -120,7 +163,7 @@ var durIO = (function() {
             
             let modifier = modNum / modDenom;
             this.writeDur(rm.simpleMinims(el, mens) * modifier, el);
-            writeAttr(el, {"rule": rule});
+            setAnnot(el.getAttribute("xml:id"), {"rule": rule});
             if (modNum !== 1 || modDenom !== 1)
             {
                 writeAttr(el, {"num": modDenom, "numbase": modNum});

--- a/js/interpreter/utils/durationUtils.js
+++ b/js/interpreter/utils/durationUtils.js
@@ -53,6 +53,17 @@ var durIO = (function() {
         return minims/MiB;
     }
 
+    function writeAttr(eventEl, dictObj) {
+        for(let attr in dictObj)
+        {
+            eventEl.setAttributeNS(null, attr, dictObj[attr]);
+        }
+    }
+
+    function readAttr(eventEl, attrName) {
+        return eventEl ? eventEl.getAttributeNS(null, attrName) : null;
+    }
+
     return {
         /** public */
 
@@ -67,7 +78,7 @@ var durIO = (function() {
             /*if(dot) {
                 num = num*1.5;
             }*/
-            el.setAttributeNS(null, 'dur.intermediate', num+'b');
+            writeAttr(el, {'dur.intermediate': num+'b'});
         },
 
         /**
@@ -82,7 +93,7 @@ var durIO = (function() {
             var scaledDur = dur * propMultiplier;
             if(dur)
             {
-                el.setAttributeNS(null, "dur.ges", scaledDur + 'b');
+                writeAttr(el, {'dur.ges': scaledDur+'b'});
             }
         },
         
@@ -109,11 +120,10 @@ var durIO = (function() {
             
             let modifier = modNum / modDenom;
             this.writeDur(rm.simpleMinims(el, mens) * modifier, el);
-            el.setAttributeNS(null, 'rule', rule);
+            writeAttr(el, {"rule": rule});
             if (modNum !== 1 || modDenom !== 1)
             {
-                el.setAttributeNS(null, 'num', modDenom);
-				el.setAttributeNS(null, 'numbase', modNum);
+                writeAttr(el, {"num": modDenom, "numbase": modNum});
             }
         },
         
@@ -132,11 +142,12 @@ var durIO = (function() {
         writeSimpleImperfection : function (el, mens, rule) {
             //	el.setAttributeNS(null, 'dur.ges', (2 * simpleMinims(el, mens) / 3) + 'b');
             this.writeDur((2 * rm.simpleMinims(el, mens) / 3), el);
-            el.setAttributeNS(null, 'num', "3");
-            el.setAttributeNS(null, 'numbase', "2");
-            el.setAttributeNS(null, 'dur.quality', 'imperfecta');
-            //el.setAttributeNS(null, 'quality', 'i');
-            el.setAttributeNS(null, 'rule', rule);
+            writeAttr(el, 
+                {"num": "3", 
+                "numbase": "2", 
+                'dur.quality': 'imperfecta',
+                "rule": rule
+            });
         },
         
         /**
@@ -155,13 +166,15 @@ var durIO = (function() {
             var factor = gcd(defaultDur, reduceBy);
             var finalDur = defaultDur - reduceBy;
             this.writeDur(finalDur, el);
-            el.setAttributeNS(null, 'num', finalDur / factor);
-            el.setAttributeNS(null, 'numbase', defaultDur / factor);
-            el.setAttributeNS(null, 'dur.quality', 'imperfecta');
-            el.setAttributeNS(null, 'rule', rule);	
+            writeAttr(el, 
+                {'num': finalDur / factor,
+                'numbase': defaultDur / factor,
+                'dur.quality': 'imperfecta',
+                'rule': rule
+            });
             if (defaultMinims === true)
             {
-                el.setAttributeNS(null, 'defaultminims', rm.simpleMinims(el, mens));
+                writeAttr(el, {'defaultminims': rm.simpleMinims(el, mens)});
             }
         },
         
@@ -177,11 +190,12 @@ var durIO = (function() {
         writeAlteration : function (el, mens, rule) {
             //	el.setAttributeNS(null, 'dur.ges', (2 * simpleMinims(el, mens)) + 'b');
             this.writeDur((2 * rm.simpleMinims(el, mens)), el);
-            el.setAttributeNS(null, 'num', "1");
-            el.setAttributeNS(null, 'numbase', "2");
-            el.setAttributeNS(null, 'dur.quality', 'altera');
-            //el.setAttributeNS(null, 'quality', 'a');
-            el.setAttributeNS(null, 'rule', rule);
+            writeAttr(el, {
+                "num": "1",
+                "numbase": "2",
+                "dur.quality": "altera",
+                "rule": rule
+            });
         },
 
         /**
@@ -195,18 +209,18 @@ var durIO = (function() {
          */
         writePerfection : function (el, mens, rule, defaultMinims = false) {
             durIO.writeDur(rm.simpleMinims(el, mens), el);
-            el.setAttributeNS(null, 'dur.quality', 'perfecta');
-            // it doesn't make sense, but maybe Verovio needs it...
-            //if(!rm.regularlyPerfect(el, mens))
-            //{
-                el.setAttributeNS(null, 'num', '2');
-                el.setAttributeNS(null, 'numbase', '3');
-            //}
+            writeAttr(el, {
+                'dur.quality': 'perfecta',
+                'num': '2',
+                'numbase': '3',
+                'rule': rule
+            });
+            // it doesn't make sense, but maybe Verovio seems to need num/numbase
+            
             if (defaultMinims === true)
             {
-                el.setAttributeNS(null, 'defaultminims', rm.simpleMinims(el, mens));
+                writeAttr(el, {'defaultminims': rm.simpleMinims(el, mens)});
             }
-            el.setAttributeNS(null, 'rule', rule);
         },
         
         /**
@@ -217,7 +231,7 @@ var durIO = (function() {
          * @memberof durIO
          */
         readDur : function (el) {
-            var str = el ? el.getAttributeNS(null, 'dur.intermediate') : null;
+            var str = readAttr(el, 'dur.intermediate');
             return str ? Number(str.substring(0, str.length-1)) : false;
         },
 
@@ -229,7 +243,7 @@ var durIO = (function() {
          * @memberof durIO
          */
         readDurGes : function (el) {
-            var str = el ? el.getAttributeNS(null, 'dur.ges') : null;
+            var str = readAttr(el, 'dur.ges');
             return str ? Number(str.substring(0, str.length-1)) : false;
         },
 
@@ -274,7 +288,7 @@ var durIO = (function() {
          * @memberof durIO
          */
         writeComment : function (el, comment) {
-            el.setAttributeNS(null, 'comment', comment);
+            writeAttr(el, {'comment': comment});
         },
         
         /**
@@ -286,8 +300,10 @@ var durIO = (function() {
          * @memberof durIO
          */
         setStartsAt : function (el, blockFrom, startsAt) {
-            el.setAttributeNS(null, 'mensurBlockStartsAt', blockFrom);
-            el.setAttributeNS(null, 'startsAt', startsAt);
+            writeAttr(el, {
+                'mensurBlockStartsAt': blockFrom,
+                'startsAt': startsAt
+            });
         },
 
         /**
@@ -297,7 +313,7 @@ var durIO = (function() {
          * @memberof durIO
          */
         readStartsAt : function (el) {
-            var startsAt = el ? el.getAttribute("startsAt"): null;
+            var startsAt = readAttr(el, "startsAt");
             return startsAt ? Number(startsAt) : false;
         },
 
@@ -308,7 +324,7 @@ var durIO = (function() {
          * @memberof durIO
          */
         readBlockFrom : function (el) {
-            var blockFrom = el ? el.getAttribute("mensurBlockStartsAt"): null;
+            var blockFrom = readAttr(el, "mensurBlockStartsAt");
             return blockFrom ? Number(blockFrom) : false;
         },
         
@@ -322,7 +338,7 @@ var durIO = (function() {
          */
         setBeatPos : function (el, blockPos, mens) {
             var beatStructure = rm.beatUnitStructure(blockPos, mens);
-            el.setAttributeNS(null, 'beatPos', beatStructure.join(', '));
+            writeAttr(el, {'beatPos': beatStructure.join(', ')});
 
             return beatStructure;
         },
@@ -339,13 +355,15 @@ var durIO = (function() {
         setBreveBoundaries : function (el, prevBeatStructure, beatStructure, minimStruct) {
             if(beatStructure[0]===0 && beatStructure[1]===0 && beatStructure[2]===0)
             {
-                el.setAttributeNS(null, 'onTheBreveBeat', beatStructure[3]);
+                writeAttr(el, {'onTheBreveBeat': beatStructure[3]});
             } 
             else if(!(beatStructure[5]===prevBeatStructure[5]
                     && beatStructure[4]===prevBeatStructure[4]
                     && beatStructure[3]===prevBeatStructure[3]))
             {
-                el.setAttributeNS(null, 'crossedABreveBeat', breveDifference(beatStructure, prevBeatStructure, minimStruct));
+                writeAttr(el, 
+                    {'crossedABreveBeat': breveDifference(beatStructure, prevBeatStructure, minimStruct)}
+                );
             }
         },
 

--- a/js/interpreter/utils/durationUtils.js
+++ b/js/interpreter/utils/durationUtils.js
@@ -188,9 +188,9 @@ var durIO = (function() {
             writeAttr(el, 
                 {"num": "3", 
                 "numbase": "2", 
-                'dur.quality': 'imperfecta',
-                "rule": rule
+                'dur.quality': 'imperfecta'
             });
+            setAnnot(el.getAttribute("xml:id"), {"rule": rule});
         },
         
         /**
@@ -212,12 +212,12 @@ var durIO = (function() {
             writeAttr(el, 
                 {'num': finalDur / factor,
                 'numbase': defaultDur / factor,
-                'dur.quality': 'imperfecta',
-                'rule': rule
+                'dur.quality': 'imperfecta'
             });
+            setAnnot(el.getAttribute("xml:id"), {"rule": rule});
             if (defaultMinims === true)
             {
-                writeAttr(el, {'defaultminims': rm.simpleMinims(el, mens)});
+                setAnnot(el.getAttribute("xml:id"), {'defaultminims': rm.simpleMinims(el, mens)});
             }
         },
         
@@ -236,9 +236,9 @@ var durIO = (function() {
             writeAttr(el, {
                 "num": "1",
                 "numbase": "2",
-                "dur.quality": "altera",
-                "rule": rule
+                "dur.quality": "altera"
             });
+            setAnnot(el.getAttribute("xml:id"), {"rule": rule});
         },
 
         /**
@@ -255,14 +255,14 @@ var durIO = (function() {
             writeAttr(el, {
                 'dur.quality': 'perfecta',
                 'num': '2',
-                'numbase': '3',
-                'rule': rule
+                'numbase': '3'
             });
+            setAnnot(el.getAttribute("xml:id"), {"rule": rule});
             // it doesn't make sense, but maybe Verovio seems to need num/numbase
             
             if (defaultMinims === true)
             {
-                writeAttr(el, {'defaultminims': rm.simpleMinims(el, mens)});
+                setAnnot(el.getAttribute("xml:id"), {'defaultminims': rm.simpleMinims(el, mens)});
             }
         },
         
@@ -331,7 +331,7 @@ var durIO = (function() {
          * @memberof durIO
          */
         writeComment : function (el, comment) {
-            writeAttr(el, {'comment': comment});
+            setAnnot(el.getAttribute("xml:id"), {'comment': comment});
         },
         
         /**

--- a/js/interpreter/utils/durationUtils.js
+++ b/js/interpreter/utils/durationUtils.js
@@ -55,6 +55,13 @@ var durIO = (function() {
 
     /** instead of attributes, annotations could be used for custom MEI export */
 
+    /**
+     * Reads the <annot> control event for an event and returns
+     * the sub-annotation for the given annotation type.
+     * @param {string} eventID xml:id of MEI event
+     * @param {string} attrName type of annotation
+     * @returns {DOMElement} annotation element
+     */
     function getAnnot(eventID, attrName) {
         var attrEl = null;
         
@@ -69,6 +76,13 @@ var durIO = (function() {
         return attrEl;
     }
 
+    /**
+     * Creates an <annot> control event connected to the given eventID.
+     * Adds sub-annotations for each key-value pair in the dictionary.
+     * Key will be the annotation type and value the annotation content.
+     * @param {string} eventID xml:id of MEI event
+     * @param {Object<string,string>} dictObj dictionary of key-value pairs
+     */
     function setAnnot(eventID, dictObj) {
         var annot;
 
@@ -96,6 +110,12 @@ var durIO = (function() {
         }
     }
 
+    /**
+     * Takes a dictionary and adds xml attributes for each key value pair.
+     * Key is used as attribute name.
+     * @param {DOMElement} eventEl 
+     * @param {Object<string,string>} dictObj 
+     */
     function writeAttr(eventEl, dictObj) {
         for(let attr in dictObj)
         {
@@ -103,6 +123,12 @@ var durIO = (function() {
         }
     }
 
+    /**
+     * Reads the value of a defined xml attribute from the given element
+     * @param {DOMElement} eventEl 
+     * @param {string} attrName 
+     * @returns the value of the defined attribute or null
+     */
     function readAttr(eventEl, attrName) {
         return eventEl ? eventEl.getAttributeNS(null, attrName) : null;
     }

--- a/js/interpreter/utils/durationUtils.js
+++ b/js/interpreter/utils/durationUtils.js
@@ -121,7 +121,7 @@ var durIO = (function() {
             /*if(dot) {
                 num = num*1.5;
             }*/
-            writeAttr(el, {'dur.intermediate': num});
+            writeAttr(el, {'dur.ppq': num});
         },
 
         /**
@@ -274,7 +274,7 @@ var durIO = (function() {
          * @memberof durIO
          */
         readDur : function (el) {
-            var str = readAttr(el, 'dur.intermediate');
+            var str = readAttr(el, 'dur.ppq');
             return str ? Number(str) : false;
         },
 

--- a/js/interpreter/utils/durationUtils.js
+++ b/js/interpreter/utils/durationUtils.js
@@ -121,7 +121,7 @@ var durIO = (function() {
             /*if(dot) {
                 num = num*1.5;
             }*/
-            writeAttr(el, {'dur.intermediate': num+'b'});
+            writeAttr(el, {'dur.intermediate': num});
         },
 
         /**
@@ -136,7 +136,7 @@ var durIO = (function() {
             var scaledDur = dur * propMultiplier;
             if(dur)
             {
-                writeAttr(el, {'dur.ges': scaledDur+'b'});
+                writeAttr(el, {'dur.ges': scaledDur});
             }
         },
         
@@ -275,7 +275,7 @@ var durIO = (function() {
          */
         readDur : function (el) {
             var str = readAttr(el, 'dur.intermediate');
-            return str ? Number(str.substring(0, str.length-1)) : false;
+            return str ? Number(str) : false;
         },
 
         /**
@@ -287,7 +287,7 @@ var durIO = (function() {
          */
         readDurGes : function (el) {
             var str = readAttr(el, 'dur.ges');
-            return str ? Number(str.substring(0, str.length-1)) : false;
+            return str ? Number(str) : false;
         },
 
         /**

--- a/js/interpreter/utils/durationUtils.js
+++ b/js/interpreter/utils/durationUtils.js
@@ -430,6 +430,39 @@ var durIO = (function() {
                     }
                 }
             }
+        },
+
+        /**
+         * Retrieves all xml attributes of the MEI event with the
+         * given xml:id and all annotations.
+         * @param {string} eventID xml:id of MEI event
+         * @returns object with attributes and anotations
+         */
+        readAllAttrs : function (eventID) {
+            let currentElement = meiFile.eventDict[eventID];
+            let currentAnnotations = meiFile.annotations[eventID];
+
+            var eventInfo = {};
+
+            eventInfo["elementName"] = currentElement.nodeName;
+
+            for (let attr of currentElement.attributes)
+            {
+                eventInfo[attr.nodeName] = attr.value;
+            }
+
+            // there are no annotations before the interpreter has run!
+            if (currentAnnotations)
+            {
+                for (let annot of currentAnnotations.children)
+                {
+                    let annotType = annot.getAttribute("type");
+                    let annotValue = annot.innerHTML;
+                    eventInfo[annotType] = annotValue;
+                }
+            }
+            
+            return eventInfo;
         }
     
     };

--- a/js/interpreter/utils/durationUtils.js
+++ b/js/interpreter/utils/durationUtils.js
@@ -63,7 +63,7 @@ var durIO = (function() {
         if(meiFile.annotations[eventID])
         {
             let annot = meiFile.annotations[eventID];
-            attrEl = meiFile.doXPathOnDoc("./annot[@type='" + attrName + "']", annot, 9).singleNodeValue;
+            attrEl = meiFile.doXPathOnDoc("./mei:annot[@type='" + attrName + "']", annot, 9).singleNodeValue;
         }
         
         return attrEl;
@@ -343,7 +343,7 @@ var durIO = (function() {
          * @memberof durIO
          */
         setStartsAt : function (el, blockFrom, startsAt) {
-            writeAttr(el, {
+            setAnnot(el.getAttribute("xml:id"), {
                 'mensurBlockStartsAt': blockFrom,
                 'startsAt': startsAt
             });
@@ -356,8 +356,8 @@ var durIO = (function() {
          * @memberof durIO
          */
         readStartsAt : function (el) {
-            var startsAt = readAttr(el, "startsAt");
-            return startsAt ? Number(startsAt) : false;
+            var startsAt = getAnnot(el.getAttribute("xml:id"), "startsAt");
+            return startsAt ? Number(startsAt.innerHTML) : false;
         },
 
         /**
@@ -367,8 +367,8 @@ var durIO = (function() {
          * @memberof durIO
          */
         readBlockFrom : function (el) {
-            var blockFrom = readAttr(el, "mensurBlockStartsAt");
-            return blockFrom ? Number(blockFrom) : false;
+            var blockFrom = getAnnot(el.getAttribute("xml:id"), "mensurBlockStartsAt");
+            return blockFrom ? Number(blockFrom.innerHTML) : false;
         },
         
         /**
@@ -381,7 +381,7 @@ var durIO = (function() {
          */
         setBeatPos : function (el, blockPos, mens) {
             var beatStructure = rm.beatUnitStructure(blockPos, mens);
-            writeAttr(el, {'beatPos': beatStructure.join(', ')});
+            setAnnot(el.getAttribute("xml:id"), {'beatPos': beatStructure.join(', ')});
 
             return beatStructure;
         },
@@ -398,13 +398,13 @@ var durIO = (function() {
         setBreveBoundaries : function (el, prevBeatStructure, beatStructure, minimStruct) {
             if(beatStructure[0]===0 && beatStructure[1]===0 && beatStructure[2]===0)
             {
-                writeAttr(el, {'onTheBreveBeat': beatStructure[3]});
+                setAnnot(el.getAttribute("xml:id"), {'onTheBreveBeat': beatStructure[3]});
             } 
             else if(!(beatStructure[5]===prevBeatStructure[5]
                     && beatStructure[4]===prevBeatStructure[4]
                     && beatStructure[3]===prevBeatStructure[3]))
             {
-                writeAttr(el, 
+                setAnnot(el.getAttribute("xml:id"), 
                     {'crossedABreveBeat': breveDifference(beatStructure, prevBeatStructure, minimStruct)}
                 );
             }

--- a/js/interpreter/utils/rhythmMensUtils.js
+++ b/js/interpreter/utils/rhythmMensUtils.js
@@ -159,19 +159,27 @@
          * @param {DOMObject} mensur mei:mensur element
          * @return {Boolean}
          * @memberof rm
+         *  @todo Something is wrong here!
          */
         regularlyPerfect : function (element, mensur){
             var val = this.noteInt(element);
-            if(val>3){
+            if(val>3)
+            {
                 if(mensur.getAttributeNS(null, 'prolatio')==="2"){
-                    if(val>4){
-                        if(mensur.getAttributeNS(null, 'tempus')==="2"){
-                            if(val>5){
+                    if(val>4)
+                    {
+                        if(mensur.getAttributeNS(null, 'tempus')==="2")
+                        {
+                            if(val>5)
+                            {
                                 if(!mensur.getAttributeNS(null, 'modusminor')
-                                    || mensur.getAttributeNS(null, 'modusminor')==="2"){
-                                    if(val>6){
+                                    || mensur.getAttributeNS(null, 'modusminor')==="2")
+                                {
+                                    if(val>6)
+                                    {
                                         if(!mensur.getAttributeNS(null, 'modusmaior')
-                                            || mensur.getAttributeNS(null, 'modusmaior')==="2"){
+                                            || mensur.getAttributeNS(null, 'modusmaior')==="2")
+                                        {
                                             return false;
                                         } else return true;
                                     } else return false
@@ -180,7 +188,8 @@
                         } else return true;
                     } else return false;
                 } else return true;
-            } else {
+            } 
+            else {
                 return false;
             }
         },

--- a/js/vrvInterface.js
+++ b/js/vrvInterface.js
@@ -151,16 +151,9 @@ var vrvInterface = (function () {
         $(eventEl).attr("fill", red);
 
         let thisID = $(eventEl).attr("id");
-        let currentElement = meiFile.eventDict[thisID];
-        let attributes = {};
-        if (currentElement)
+        let attributes = durIO.readAllAttrs(thisID);
+        if (attributes)
         {
-            for (let attr of currentElement.attributes)
-            {
-                attributes[attr.nodeName] = attr.value;
-            }
-            
-
             let elementInfo = $("<dl id='attList' class='row'></dl>");
             for (let attr in attributes)
             {
@@ -170,7 +163,7 @@ var vrvInterface = (function () {
                 $(elementInfo).append(dd);
             }
             
-            let elCode = makeXmlCode(currentElement.outerHTML);
+            let elCode = makeXmlCode(meiFile.eventDict[thisID].outerHTML);
             
             let heading = $("<h3>Element info</h3>");
             let hideButton = $("<button id='hideInfo' class='btn btn-secondary btn-sm float-right mt-1'>X</button>");

--- a/rules.markdown
+++ b/rules.markdown
@@ -7,6 +7,8 @@ permalink: /rules/
 
 ## Beat independent rules
 
+In order of execution:
+
 rest
 : Rests can't be altered or imperfected.
 
@@ -26,7 +28,7 @@ unalteredImperfectAfterLarger
 : An alterable note preceded by a larger note is followed by a larger note and regularly imperfect.
 
 A.2b
-: An alterable note that is preceded by a larger note followed by the equivalent of its own regular value and followed by a note or rest of the perfect unit next larger is altered.
+: ???
 
 unalteredImperfect
 : A regularly imperfect alterable note that is not followed by a larger note.
@@ -39,6 +41,7 @@ I.2.b.antesim
 ### Imperfection
 
 I.3
+: A regularly perfect note that falls on the first subunit of its own unit and is followed by any larger note or rest is ipso facto perfect.
 
 I.4a
 
@@ -60,6 +63,7 @@ I.6-literalunits
 : Trusting in alteration
 
 I.8
+: A regularly perfect note that falls on the second subunit of its own unit is imperfected from ahead by what would imperfect it, either immediately or by syncope.
 
 I.9a
 
@@ -71,6 +75,7 @@ A.1
 : An alterable note on the second beat gets altered.
 
 A.2
+: An alterable note that is preceded by a dot of division followed by the equivalent of its own regular value and followed by a note or rest of the perfect unit next larger is altered.
 
 A.xxx
 


### PR DESCRIPTION
Interpreter output has been revised to be MEI 4/5 compliant.
Non-valid attributes were moved to newly added `<annot>` control events within `<staff>` (not valid with MEI 3).
Every property is stored in a child annotation with the old attribute name as `@type`.
`@dur.intermediate` has been renamed to `@dur.ppq` and the value has been changed to a non negative number.

`@dur.ges` is deactivated for now until we start with proportion support.
